### PR TITLE
Add C-implementation for builds on stable rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: rust
 services: docker
 sudo: required
 
-rust: nightly
-
 env: TARGET=x86_64-unknown-linux-gnu
 matrix:
   include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ name = "sc"
 readme = "README.md"
 repository = "https://github.com/japaric/syscall.rs"
 version = "0.2.2"
+
+[build-dependencies]
+cc = "1.0.37"
+rustc_version = "0.2.3"
+target_build_utils = "0.3.1"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,36 @@
+extern crate rustc_version;
+extern crate target_build_utils;
+use rustc_version::{version_meta, Channel};
+
+fn main() {
+    match version_meta()
+        .expect("Failed to determine Rustc version information")
+        .channel
+    {
+        Channel::Stable | Channel::Beta => {
+            let target = target_build_utils::TargetInfo::new().unwrap();
+
+            println!("{:#?}", target);
+
+            let native_src = match (
+                target.target_arch(),
+                target.target_vendor(),
+                target.target_os(),
+                target.target_env(),
+            ) {
+                ("x86_64", _, "freebsd", _)
+                | ("x86_64", _, "linux", _)
+                | ("x86_64", _, "macos", _) => "native/x86_64-abi.c",
+                ("x86", _, "linux", _) => "native/linux-x86.c",
+                ("arm", _, "linux", _) => "native/linux-armeabi.c",
+                _ => unimplemented!("Target {} is not supported on stable rust", std::env::var("TARGET").unwrap()),
+            };
+
+            cc::Build::new().file(native_src).compile("platform");
+            println!("cargo:rustc-cfg=native");
+        }
+        Channel::Nightly | Channel::Dev => {
+            println!("cargo:rustc-cfg=asm");
+        }
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,12 @@ fn main() {
                 | ("x86_64", _, "macos", _) => "native/x86_64-abi.c",
                 ("x86", _, "linux", _) => "native/linux-x86.c",
                 ("arm", _, "linux", _) => "native/linux-armeabi.c",
-                _ => unimplemented!("Target {} is not supported on stable rust", std::env::var("TARGET").unwrap()),
+                ("powerpc", _, "linux", _)
+                | ("powerpc64", _, "linux", _) => "native/linux-powerpc.c",
+                _ => unimplemented!(
+                    "Target {} is not supported on stable rust",
+                    std::env::var("TARGET").unwrap()
+                ),
             };
 
             cc::Build::new().file(native_src).compile("platform");

--- a/native/linux-armeabi.c
+++ b/native/linux-armeabi.c
@@ -1,0 +1,76 @@
+long syscall0(long n) {
+    register long r7 __asm__("r7") = n;
+    register long r0 __asm__("r0");
+    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7) : "memory");
+    return r0;
+}
+
+long syscall1(long n, long a1) {
+    register long r7 __asm__("r7") = n;
+    register long r0 __asm__("r0") = a1;
+    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0) : "memory");
+    return r0;
+}
+
+long syscall2(long n, long a1, long a2) {
+    register long r7 __asm__("r7") = n;
+    register long r0 __asm__("r0") = a1;
+    register long r1 __asm__("r1") = a2;
+    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1) : "memory");
+    return r0;
+}
+
+long syscall3(long n, long a1, long a2, long a3) {
+    register long r7 __asm__("r7") = n;
+    register long r0 __asm__("r0") = a1;
+    register long r1 __asm__("r1") = a2;
+    register long r2 __asm__("r2") = a3;
+    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1), "r"(r2) : "memory");
+    return r0;
+}
+
+long syscall4(long n, long a1, long a2, long a3, long a4) {
+    register long r7 __asm__("r7") = n;
+    register long r0 __asm__("r0") = a1;
+    register long r1 __asm__("r1") = a2;
+    register long r2 __asm__("r2") = a3;
+    register long r3 __asm__("r3") = a4;
+    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3) : "memory");
+    return r0;
+}
+
+long syscall5(long n, long a1, long a2, long a3, long a4, long a5) {
+    register long r7 __asm__("r7") = n;
+    register long r0 __asm__("r0") = a1;
+    register long r1 __asm__("r1") = a2;
+    register long r2 __asm__("r2") = a3;
+    register long r3 __asm__("r3") = a4;
+    register long r4 __asm__("r4") = a5;
+    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4) : "memory");
+    return r0;
+}
+
+long syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6) {
+    register long r7 __asm__("r7") = n;
+    register long r0 __asm__("r0") = a1;
+    register long r1 __asm__("r1") = a2;
+    register long r2 __asm__("r2") = a3;
+    register long r3 __asm__("r3") = a4;
+    register long r4 __asm__("r4") = a5;
+    register long r5 __asm__("r5") = a6;
+    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4), "r"(r5) : "memory");
+    return r0;
+}
+
+long syscall7(long n, long a1, long a2, long a3, long a4, long a5, long a6, long a7) {
+    register long r7 __asm__("r7") = n;
+    register long r0 __asm__("r0") = a1;
+    register long r1 __asm__("r1") = a2;
+    register long r2 __asm__("r2") = a3;
+    register long r3 __asm__("r3") = a4;
+    register long r4 __asm__("r4") = a5;
+    register long r5 __asm__("r5") = a6;
+    register long r6 __asm__("r6") = a7;
+    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4), "r"(r5), "r"(r6) : "memory");
+    return r0;
+}

--- a/native/linux-armeabi.c
+++ b/native/linux-armeabi.c
@@ -1,76 +1,97 @@
 long syscall0(long n) {
-    register long r7 __asm__("r7") = n;
-    register long r0 __asm__("r0");
-    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7) : "memory");
-    return r0;
+  register long r7 __asm__("r7") = n;
+  register long r0 __asm__("r0");
+  __asm__ __volatile__("swi $0" : "=r"(r0) : "r"(r7) : "memory");
+  return r0;
 }
 
 long syscall1(long n, long a1) {
-    register long r7 __asm__("r7") = n;
-    register long r0 __asm__("r0") = a1;
-    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0) : "memory");
-    return r0;
+  register long r7 __asm__("r7") = n;
+  register long r0 __asm__("r0") = a1;
+  __asm__ __volatile__("swi $0" : "=r"(r0) : "r"(r7), "r"(r0) : "memory");
+  return r0;
 }
 
 long syscall2(long n, long a1, long a2) {
-    register long r7 __asm__("r7") = n;
-    register long r0 __asm__("r0") = a1;
-    register long r1 __asm__("r1") = a2;
-    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1) : "memory");
-    return r0;
+  register long r7 __asm__("r7") = n;
+  register long r0 __asm__("r0") = a1;
+  register long r1 __asm__("r1") = a2;
+  __asm__ __volatile__("swi $0"
+                       : "=r"(r0)
+                       : "r"(r7), "r"(r0), "r"(r1)
+                       : "memory");
+  return r0;
 }
 
 long syscall3(long n, long a1, long a2, long a3) {
-    register long r7 __asm__("r7") = n;
-    register long r0 __asm__("r0") = a1;
-    register long r1 __asm__("r1") = a2;
-    register long r2 __asm__("r2") = a3;
-    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1), "r"(r2) : "memory");
-    return r0;
+  register long r7 __asm__("r7") = n;
+  register long r0 __asm__("r0") = a1;
+  register long r1 __asm__("r1") = a2;
+  register long r2 __asm__("r2") = a3;
+  __asm__ __volatile__("swi $0"
+                       : "=r"(r0)
+                       : "r"(r7), "r"(r0), "r"(r1), "r"(r2)
+                       : "memory");
+  return r0;
 }
 
 long syscall4(long n, long a1, long a2, long a3, long a4) {
-    register long r7 __asm__("r7") = n;
-    register long r0 __asm__("r0") = a1;
-    register long r1 __asm__("r1") = a2;
-    register long r2 __asm__("r2") = a3;
-    register long r3 __asm__("r3") = a4;
-    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3) : "memory");
-    return r0;
+  register long r7 __asm__("r7") = n;
+  register long r0 __asm__("r0") = a1;
+  register long r1 __asm__("r1") = a2;
+  register long r2 __asm__("r2") = a3;
+  register long r3 __asm__("r3") = a4;
+  __asm__ __volatile__("swi $0"
+                       : "=r"(r0)
+                       : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3)
+                       : "memory");
+  return r0;
 }
 
 long syscall5(long n, long a1, long a2, long a3, long a4, long a5) {
-    register long r7 __asm__("r7") = n;
-    register long r0 __asm__("r0") = a1;
-    register long r1 __asm__("r1") = a2;
-    register long r2 __asm__("r2") = a3;
-    register long r3 __asm__("r3") = a4;
-    register long r4 __asm__("r4") = a5;
-    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4) : "memory");
-    return r0;
+  register long r7 __asm__("r7") = n;
+  register long r0 __asm__("r0") = a1;
+  register long r1 __asm__("r1") = a2;
+  register long r2 __asm__("r2") = a3;
+  register long r3 __asm__("r3") = a4;
+  register long r4 __asm__("r4") = a5;
+  __asm__ __volatile__("swi $0"
+                       : "=r"(r0)
+                       : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4)
+                       : "memory");
+  return r0;
 }
 
 long syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6) {
-    register long r7 __asm__("r7") = n;
-    register long r0 __asm__("r0") = a1;
-    register long r1 __asm__("r1") = a2;
-    register long r2 __asm__("r2") = a3;
-    register long r3 __asm__("r3") = a4;
-    register long r4 __asm__("r4") = a5;
-    register long r5 __asm__("r5") = a6;
-    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4), "r"(r5) : "memory");
-    return r0;
+  register long r7 __asm__("r7") = n;
+  register long r0 __asm__("r0") = a1;
+  register long r1 __asm__("r1") = a2;
+  register long r2 __asm__("r2") = a3;
+  register long r3 __asm__("r3") = a4;
+  register long r4 __asm__("r4") = a5;
+  register long r5 __asm__("r5") = a6;
+  __asm__ __volatile__("swi $0"
+                       : "=r"(r0)
+                       : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4),
+                         "r"(r5)
+                       : "memory");
+  return r0;
 }
 
-long syscall7(long n, long a1, long a2, long a3, long a4, long a5, long a6, long a7) {
-    register long r7 __asm__("r7") = n;
-    register long r0 __asm__("r0") = a1;
-    register long r1 __asm__("r1") = a2;
-    register long r2 __asm__("r2") = a3;
-    register long r3 __asm__("r3") = a4;
-    register long r4 __asm__("r4") = a5;
-    register long r5 __asm__("r5") = a6;
-    register long r6 __asm__("r6") = a7;
-    __asm__ __volatile__ ("swi $0" : "=r"(r0) : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4), "r"(r5), "r"(r6) : "memory");
-    return r0;
+long syscall7(long n, long a1, long a2, long a3, long a4, long a5, long a6,
+              long a7) {
+  register long r7 __asm__("r7") = n;
+  register long r0 __asm__("r0") = a1;
+  register long r1 __asm__("r1") = a2;
+  register long r2 __asm__("r2") = a3;
+  register long r3 __asm__("r3") = a4;
+  register long r4 __asm__("r4") = a5;
+  register long r5 __asm__("r5") = a6;
+  register long r6 __asm__("r6") = a7;
+  __asm__ __volatile__("swi $0"
+                       : "=r"(r0)
+                       : "r"(r7), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "r"(r4),
+                         "r"(r5), "r"(r6)
+                       : "memory");
+  return r0;
 }

--- a/native/linux-powerpc.c
+++ b/native/linux-powerpc.c
@@ -1,0 +1,80 @@
+long syscall0(long n) {
+  register long r0 __asm__("r0") = n;
+  register long r3 __asm__("r3");
+  __asm__ __volatile__("sc ; bns+ 1f ; neg %1, %1 ; 1:"
+                       : "+r"(r0), "=r"(r3)::"memory", "cr0", "r4", "r5", "r6",
+                         "r7", "r8", "r9", "r10", "r11", "r12");
+  return r3;
+}
+
+long syscall1(long n, long a1) {
+  register long r0 __asm__("r0") = n;
+  register long r3 __asm__("r3") = a1;
+  __asm__ __volatile__("sc ; bns+ 1f ; neg %1, %1 ; 1:"
+                       : "+r"(r0), "+r"(r3)::"memory", "cr0", "r4", "r5", "r6",
+                         "r7", "r8", "r9", "r10", "r11", "r12");
+  return r3;
+}
+
+long syscall2(long n, long a1, long a2) {
+  register long r0 __asm__("r0") = n;
+  register long r3 __asm__("r3") = a1;
+  register long r4 __asm__("r4") = a2;
+  __asm__ __volatile__("sc ; bns+ 1f ; neg %1, %1 ; 1:"
+                       : "+r"(r0), "+r"(r3), "+r"(r4)::"memory", "cr0", "r5",
+                         "r6", "r7", "r8", "r9", "r10", "r11", "r12");
+  return r3;
+}
+
+long syscall3(long n, long a1, long a2, long a3) {
+  register long r0 __asm__("r0") = n;
+  register long r3 __asm__("r3") = a1;
+  register long r4 __asm__("r4") = a2;
+  register long r5 __asm__("r5") = a3;
+  __asm__ __volatile__("sc ; bns+ 1f ; neg %1, %1 ; 1:"
+                       : "+r"(r0), "+r"(r3), "+r"(r4), "+r"(r5)::"memory",
+                         "cr0", "r6", "r7", "r8", "r9", "r10", "r11", "r12");
+  return r3;
+}
+
+long syscall4(long n, long a1, long a2, long a3, long a4) {
+  register long r0 __asm__("r0") = n;
+  register long r3 __asm__("r3") = a1;
+  register long r4 __asm__("r4") = a2;
+  register long r5 __asm__("r5") = a3;
+  register long r6 __asm__("r6") = a4;
+  __asm__ __volatile__("sc ; bns+ 1f ; neg %1, %1 ; 1:"
+                       : "+r"(r0), "+r"(r3), "+r"(r4), "+r"(r5),
+                         "+r"(r6)::"memory", "cr0", "r7", "r8", "r9", "r10",
+                         "r11", "r12");
+  return r3;
+}
+
+long syscall5(long n, long a1, long a2, long a3, long a4, long a5) {
+  register long r0 __asm__("r0") = n;
+  register long r3 __asm__("r3") = a1;
+  register long r4 __asm__("r4") = a2;
+  register long r5 __asm__("r5") = a3;
+  register long r6 __asm__("r6") = a4;
+  register long r7 __asm__("r7") = a5;
+  __asm__ __volatile__("sc ; bns+ 1f ; neg %1, %1 ; 1:"
+                       : "+r"(r0), "+r"(r3), "+r"(r4), "+r"(r5), "+r"(r6),
+                         "+r"(r7)::"memory", "cr0", "r8", "r9", "r10", "r11",
+                         "r12");
+  return r3;
+}
+
+long syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6) {
+  register long r0 __asm__("r0") = n;
+  register long r3 __asm__("r3") = a1;
+  register long r4 __asm__("r4") = a2;
+  register long r5 __asm__("r5") = a3;
+  register long r6 __asm__("r6") = a4;
+  register long r7 __asm__("r7") = a5;
+  register long r8 __asm__("r8") = a6;
+  __asm__ __volatile__("sc ; bns+ 1f ; neg %1, %1 ; 1:"
+                       : "+r"(r0), "+r"(r3), "+r"(r4), "+r"(r5), "+r"(r6),
+                         "+r"(r7), "+r"(r8)::"memory", "cr0", "r9", "r10",
+                         "r11", "r12");
+  return r3;
+}

--- a/native/linux-x86.c
+++ b/native/linux-x86.c
@@ -1,0 +1,48 @@
+long syscall0(long n)
+{
+  unsigned long __ret;
+  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n) : "memory");
+  return __ret;
+}
+
+long syscall1(long n, long a1)
+{
+  unsigned long __ret;
+  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n), "b"(a1) : "memory");
+  return __ret;
+}
+
+long syscall2(long n, long a1, long a2)
+{
+  unsigned long __ret;
+  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2) : "memory");
+  return __ret;
+}
+
+long syscall3(long n, long a1, long a2, long a3)
+{
+  unsigned long __ret;
+  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2), "d"(a3) : "memory");
+  return __ret;
+}
+
+long syscall4(long n, long a1, long a2, long a3, long a4)
+{
+  unsigned long __ret;
+  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2), "d"(a3), "S"(a4) : "memory");
+  return __ret;
+}
+
+long syscall5(long n, long a1, long a2, long a3, long a4, long a5)
+{
+  unsigned long __ret;
+  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2), "d"(a3), "S"(a4), "D"(a5) : "memory");
+  return __ret;
+}
+
+long syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6)
+{
+  unsigned long __ret;
+  __asm__ __volatile__ ("pushl %7 ; push %%ebp ; mov 4(%%esp),%%ebp ; int $128 ; pop %%ebp ; add $4,%%esp" : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2), "d"(a3), "S"(a4), "D"(a5), "g"(a6) : "memory");
+  return __ret;
+}

--- a/native/linux-x86.c
+++ b/native/linux-x86.c
@@ -1,48 +1,58 @@
-long syscall0(long n)
-{
+long syscall0(long n) {
   unsigned long __ret;
-  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n) : "memory");
+  __asm__ __volatile__("int $128" : "=a"(__ret) : "a"(n) : "memory");
   return __ret;
 }
 
-long syscall1(long n, long a1)
-{
+long syscall1(long n, long a1) {
   unsigned long __ret;
-  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n), "b"(a1) : "memory");
+  __asm__ __volatile__("int $128" : "=a"(__ret) : "a"(n), "b"(a1) : "memory");
   return __ret;
 }
 
-long syscall2(long n, long a1, long a2)
-{
+long syscall2(long n, long a1, long a2) {
   unsigned long __ret;
-  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2) : "memory");
+  __asm__ __volatile__("int $128"
+                       : "=a"(__ret)
+                       : "a"(n), "b"(a1), "c"(a2)
+                       : "memory");
   return __ret;
 }
 
-long syscall3(long n, long a1, long a2, long a3)
-{
+long syscall3(long n, long a1, long a2, long a3) {
   unsigned long __ret;
-  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2), "d"(a3) : "memory");
+  __asm__ __volatile__("int $128"
+                       : "=a"(__ret)
+                       : "a"(n), "b"(a1), "c"(a2), "d"(a3)
+                       : "memory");
   return __ret;
 }
 
-long syscall4(long n, long a1, long a2, long a3, long a4)
-{
+long syscall4(long n, long a1, long a2, long a3, long a4) {
   unsigned long __ret;
-  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2), "d"(a3), "S"(a4) : "memory");
+  __asm__ __volatile__("int $128"
+                       : "=a"(__ret)
+                       : "a"(n), "b"(a1), "c"(a2), "d"(a3), "S"(a4)
+                       : "memory");
   return __ret;
 }
 
-long syscall5(long n, long a1, long a2, long a3, long a4, long a5)
-{
+long syscall5(long n, long a1, long a2, long a3, long a4, long a5) {
   unsigned long __ret;
-  __asm__ __volatile__ ("int $128" : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2), "d"(a3), "S"(a4), "D"(a5) : "memory");
+  __asm__ __volatile__("int $128"
+                       : "=a"(__ret)
+                       : "a"(n), "b"(a1), "c"(a2), "d"(a3), "S"(a4), "D"(a5)
+                       : "memory");
   return __ret;
 }
 
-long syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6)
-{
+long syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6) {
   unsigned long __ret;
-  __asm__ __volatile__ ("pushl %7 ; push %%ebp ; mov 4(%%esp),%%ebp ; int $128 ; pop %%ebp ; add $4,%%esp" : "=a"(__ret) : "a"(n), "b"(a1), "c"(a2), "d"(a3), "S"(a4), "D"(a5), "g"(a6) : "memory");
+  __asm__ __volatile__("pushl %7 ; push %%ebp ; mov 4(%%esp),%%ebp ; int $128 "
+                       "; pop %%ebp ; add $4,%%esp"
+                       : "=a"(__ret)
+                       : "a"(n), "b"(a1), "c"(a2), "d"(a3), "S"(a4), "D"(a5),
+                         "g"(a6)
+                       : "memory");
   return __ret;
 }

--- a/native/x86_64-abi.c
+++ b/native/x86_64-abi.c
@@ -1,0 +1,54 @@
+long syscall0(long n)
+{
+  unsigned long ret;
+  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n) : "rcx", "r11", "memory");
+  return ret;
+}
+
+long syscall1(long n, long a1)
+{
+  unsigned long ret;
+  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1) : "rcx", "r11", "memory");
+  return ret;
+}
+
+long syscall2(long n, long a1, long a2)
+{
+  unsigned long ret;
+  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1), "S"(a2) : "rcx", "r11", "memory");
+  return ret;
+}
+
+long syscall3(long n, long a1, long a2, long a3)
+{
+  unsigned long ret;
+  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1), "S"(a2), "d"(a3) : "rcx", "r11", "memory");
+  return ret;
+}
+
+long syscall4(long n, long a1, long a2, long a3, long a4)
+{
+  unsigned long ret;
+  register long r10 __asm__("r10") = a4;
+  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10): "rcx", "r11", "memory");
+  return ret;
+}
+
+long syscall5(long n, long a1, long a2, long a3, long a4, long a5)
+{
+  unsigned long ret;
+  register long r10 __asm__("r10") = a4;
+  register long r8 __asm__("r8") = a5;
+  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8) : "rcx", "r11", "memory");
+  return ret;
+}
+
+long syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6)
+{
+  unsigned long ret;
+  register long r10 __asm__("r10") = a4;
+  register long r8 __asm__("r8") = a5;
+  register long r9 __asm__("r9") = a6;
+  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8), "r"(r9) : "rcx", "r11", "memory");
+  return ret;
+}

--- a/native/x86_64-abi.c
+++ b/native/x86_64-abi.c
@@ -1,54 +1,66 @@
-long syscall0(long n)
-{
+long syscall0(long n) {
   unsigned long ret;
-  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n) : "rcx", "r11", "memory");
+  __asm__ __volatile__("syscall" : "=a"(ret) : "a"(n) : "rcx", "r11", "memory");
   return ret;
 }
 
-long syscall1(long n, long a1)
-{
+long syscall1(long n, long a1) {
   unsigned long ret;
-  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1) : "rcx", "r11", "memory");
+  __asm__ __volatile__("syscall"
+                       : "=a"(ret)
+                       : "a"(n), "D"(a1)
+                       : "rcx", "r11", "memory");
   return ret;
 }
 
-long syscall2(long n, long a1, long a2)
-{
+long syscall2(long n, long a1, long a2) {
   unsigned long ret;
-  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1), "S"(a2) : "rcx", "r11", "memory");
+  __asm__ __volatile__("syscall"
+                       : "=a"(ret)
+                       : "a"(n), "D"(a1), "S"(a2)
+                       : "rcx", "r11", "memory");
   return ret;
 }
 
-long syscall3(long n, long a1, long a2, long a3)
-{
+long syscall3(long n, long a1, long a2, long a3) {
   unsigned long ret;
-  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1), "S"(a2), "d"(a3) : "rcx", "r11", "memory");
+  __asm__ __volatile__("syscall"
+                       : "=a"(ret)
+                       : "a"(n), "D"(a1), "S"(a2), "d"(a3)
+                       : "rcx", "r11", "memory");
   return ret;
 }
 
-long syscall4(long n, long a1, long a2, long a3, long a4)
-{
+long syscall4(long n, long a1, long a2, long a3, long a4) {
   unsigned long ret;
   register long r10 __asm__("r10") = a4;
-  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10): "rcx", "r11", "memory");
+  __asm__ __volatile__("syscall"
+                       : "=a"(ret)
+                       : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10)
+                       : "rcx", "r11", "memory");
   return ret;
 }
 
-long syscall5(long n, long a1, long a2, long a3, long a4, long a5)
-{
+long syscall5(long n, long a1, long a2, long a3, long a4, long a5) {
   unsigned long ret;
   register long r10 __asm__("r10") = a4;
   register long r8 __asm__("r8") = a5;
-  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8) : "rcx", "r11", "memory");
+  __asm__ __volatile__("syscall"
+                       : "=a"(ret)
+                       : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8)
+                       : "rcx", "r11", "memory");
   return ret;
 }
 
-long syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6)
-{
+long syscall6(long n, long a1, long a2, long a3, long a4, long a5, long a6) {
   unsigned long ret;
   register long r10 __asm__("r10") = a4;
   register long r8 __asm__("r8") = a5;
   register long r9 __asm__("r9") = a6;
-  __asm__ __volatile__ ("syscall" : "=a"(ret) : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8), "r"(r9) : "rcx", "r11", "memory");
+  __asm__ __volatile__("syscall"
+                       : "=a"(ret)
+                       : "a"(n), "D"(a1), "S"(a2), "d"(a3), "r"(r10), "r"(r8),
+                         "r"(r9)
+                       : "rcx", "r11", "memory");
   return ret;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,8 @@
 //! Raw system calls for Rust.
 
 // Reference http://man7.org/linux/man-pages/man2/syscall.2.html
-
 #![deny(warnings)]
-#![feature(asm)]
+#![cfg_attr(asm, feature(asm))]
 #![no_std]
 
 #[cfg(test)]
@@ -21,6 +20,38 @@ extern crate std;
 pub use platform::*;
 
 pub mod macros;
+
+#[cfg(native)]
+extern "C" {
+    pub fn syscall0(n: usize) -> usize;
+    pub fn syscall1(n: usize, a1: usize) -> usize;
+    pub fn syscall2(n: usize, a1: usize, a2: usize) -> usize;
+    pub fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize;
+    pub fn syscall4(n: usize, a1: usize, a2: usize, a3: usize, a4: usize) -> usize;
+    pub fn syscall5(n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) -> usize;
+    pub fn syscall6(
+        n: usize,
+        a1: usize,
+        a2: usize,
+        a3: usize,
+        a4: usize,
+        a5: usize,
+        a6: usize,
+    ) -> usize;
+}
+#[cfg(all(native, target_os = "linux", target_arch = "arm"))]
+extern "C" {
+    pub fn syscall7(
+        n: usize,
+        a1: usize,
+        a2: usize,
+        a3: usize,
+        a4: usize,
+        a5: usize,
+        a6: usize,
+        a7: usize,
+    ) -> usize;
+}
 
 #[cfg(all(target_os = "linux",
           target_arch = "aarch64"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,57 +53,46 @@ extern "C" {
     ) -> usize;
 }
 
-#[cfg(all(target_os = "linux",
-          target_arch = "aarch64"))]
-#[path="platform/linux-aarch64/mod.rs"]
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+#[path = "platform/linux-aarch64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
-          target_arch = "arm"))]
-#[path="platform/linux-armeabi/mod.rs"]
+#[cfg(all(target_os = "linux", target_arch = "arm"))]
+#[path = "platform/linux-armeabi/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
-          target_arch = "mips"))]
-#[path="platform/linux-mips/mod.rs"]
+#[cfg(all(target_os = "linux", target_arch = "mips"))]
+#[path = "platform/linux-mips/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
-          target_arch = "mips64"))]
-#[path="platform/linux-mips64/mod.rs"]
+#[cfg(all(target_os = "linux", target_arch = "mips64"))]
+#[path = "platform/linux-mips64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
-          target_arch = "powerpc"))]
-#[path="platform/linux-powerpc/mod.rs"]
+#[cfg(all(target_os = "linux", target_arch = "powerpc"))]
+#[path = "platform/linux-powerpc/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
-          target_arch = "powerpc64"))]
-#[path="platform/linux-powerpc64/mod.rs"]
+#[cfg(all(target_os = "linux", target_arch = "powerpc64"))]
+#[path = "platform/linux-powerpc64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
-          target_arch = "sparc64"))]
-#[path="platform/linux-sparc64/mod.rs"]
+#[cfg(all(target_os = "linux", target_arch = "sparc64"))]
+#[path = "platform/linux-sparc64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
-          target_arch = "x86"))]
-#[path="platform/linux-x86/mod.rs"]
+#[cfg(all(target_os = "linux", target_arch = "x86"))]
+#[path = "platform/linux-x86/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
-          target_arch = "x86_64"))]
-#[path="platform/linux-x86_64/mod.rs"]
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[path = "platform/linux-x86_64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "freebsd",
-          target_arch = "x86_64"))]
-#[path="platform/freebsd-x86_64/mod.rs"]
+#[cfg(all(target_os = "freebsd", target_arch = "x86_64"))]
+#[path = "platform/freebsd-x86_64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "macos",
-          target_arch = "x86_64"))]
-#[path="platform/macos-x86_64/mod.rs"]
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+#[path = "platform/macos-x86_64/mod.rs"]
 pub mod platform;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,47 +10,65 @@
 
 #[macro_export]
 macro_rules! syscall {
-    ($nr:ident)
-        => ( ::sc::syscall0(
-                ::sc::nr::$nr) );
+    ($nr:ident) => {
+        ::sc::syscall0(::sc::nr::$nr)
+    };
 
-    ($nr:ident, $a1:expr)
-        => ( ::sc::syscall1(
-                ::sc::nr::$nr,
-                $a1 as usize) );
+    ($nr:ident, $a1:expr) => {
+        ::sc::syscall1(::sc::nr::$nr, $a1 as usize)
+    };
 
-    ($nr:ident, $a1:expr, $a2:expr)
-        => ( ::sc::syscall2(
-                ::sc::nr::$nr,
-                $a1 as usize, $a2 as usize) );
+    ($nr:ident, $a1:expr, $a2:expr) => {
+        ::sc::syscall2(::sc::nr::$nr, $a1 as usize, $a2 as usize)
+    };
 
-    ($nr:ident, $a1:expr, $a2:expr, $a3:expr)
-        => ( ::sc::syscall3(
-                ::sc::nr::$nr,
-                $a1 as usize, $a2 as usize, $a3 as usize) );
+    ($nr:ident, $a1:expr, $a2:expr, $a3:expr) => {
+        ::sc::syscall3(::sc::nr::$nr, $a1 as usize, $a2 as usize, $a3 as usize)
+    };
 
-    ($nr:ident, $a1:expr, $a2:expr, $a3:expr, $a4:expr)
-        => ( ::sc::syscall4(
-                ::sc::nr::$nr,
-                $a1 as usize, $a2 as usize, $a3 as usize,
-                $a4 as usize) );
+    ($nr:ident, $a1:expr, $a2:expr, $a3:expr, $a4:expr) => {
+        ::sc::syscall4(
+            ::sc::nr::$nr,
+            $a1 as usize,
+            $a2 as usize,
+            $a3 as usize,
+            $a4 as usize,
+        )
+    };
 
-    ($nr:ident, $a1:expr, $a2:expr, $a3:expr, $a4:expr, $a5:expr)
-        => ( ::sc::syscall5(
-                ::sc::nr::$nr,
-                $a1 as usize, $a2 as usize, $a3 as usize,
-                $a4 as usize, $a5 as usize) );
+    ($nr:ident, $a1:expr, $a2:expr, $a3:expr, $a4:expr, $a5:expr) => {
+        ::sc::syscall5(
+            ::sc::nr::$nr,
+            $a1 as usize,
+            $a2 as usize,
+            $a3 as usize,
+            $a4 as usize,
+            $a5 as usize,
+        )
+    };
 
-    ($nr:ident, $a1:expr, $a2:expr, $a3:expr, $a4:expr, $a5:expr, $a6:expr)
-        => ( ::sc::syscall6(
-                ::sc::nr::$nr,
-                $a1 as usize, $a2 as usize, $a3 as usize,
-                $a4 as usize, $a5 as usize, $a6 as usize) );
+    ($nr:ident, $a1:expr, $a2:expr, $a3:expr, $a4:expr, $a5:expr, $a6:expr) => {
+        ::sc::syscall6(
+            ::sc::nr::$nr,
+            $a1 as usize,
+            $a2 as usize,
+            $a3 as usize,
+            $a4 as usize,
+            $a5 as usize,
+            $a6 as usize,
+        )
+    };
 
-    ($nr:ident, $a1:expr, $a2:expr, $a3:expr, $a4:expr, $a5:expr, $a6:expr, $a7:expr)
-        => ( ::sc::syscall7(
-                ::sc::nr::$nr,
-                $a1 as usize, $a2 as usize, $a3 as usize,
-                $a4 as usize, $a5 as usize, $a6 as usize,
-                $a7 as usize) );
+    ($nr:ident, $a1:expr, $a2:expr, $a3:expr, $a4:expr, $a5:expr, $a6:expr, $a7:expr) => {
+        ::sc::syscall7(
+            ::sc::nr::$nr,
+            $a1 as usize,
+            $a2 as usize,
+            $a3 as usize,
+            $a4 as usize,
+            $a5 as usize,
+            $a6 as usize,
+            $a7 as usize,
+        )
+    };
 }

--- a/src/platform/freebsd-x86_64/mod.rs
+++ b/src/platform/freebsd-x86_64/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod nr;
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret: usize;
@@ -21,6 +22,7 @@ pub unsafe fn syscall0(n: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     let ret: usize;
@@ -31,6 +33,7 @@ pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     let ret: usize;
@@ -41,6 +44,7 @@ pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     let ret: usize;
@@ -51,6 +55,7 @@ pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall4(n: usize,
                        a1: usize,
@@ -67,6 +72,7 @@ pub unsafe fn syscall4(n: usize,
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall5(n: usize,
                        a1: usize,
@@ -84,6 +90,7 @@ pub unsafe fn syscall5(n: usize,
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall6(n: usize,
                        a1: usize,

--- a/src/platform/freebsd-x86_64/mod.rs
+++ b/src/platform/freebsd-x86_64/mod.rs
@@ -57,12 +57,7 @@ pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall4(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize, a4: usize) -> usize {
     let ret: usize;
     asm!("syscall" : "={rax}"(ret)
                    : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
@@ -74,13 +69,7 @@ pub unsafe fn syscall4(n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall5(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) -> usize {
     let ret: usize;
     asm!("syscall" : "={rax}"(ret)
                    : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
@@ -92,14 +81,15 @@ pub unsafe fn syscall5(n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall6(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize,
-                       a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    n: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+    a6: usize,
+) -> usize {
     let ret: usize;
     asm!("syscall" : "={rax}"(ret)
                    : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),

--- a/src/platform/linux-aarch64/mod.rs
+++ b/src/platform/linux-aarch64/mod.rs
@@ -56,12 +56,7 @@ pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
 }
 
 #[inline(always)]
-pub unsafe fn syscall4(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize, a4: usize) -> usize {
     let ret: usize;
     asm!("svc 0"
          : "={x0}"(ret)
@@ -72,13 +67,7 @@ pub unsafe fn syscall4(n: usize,
 }
 
 #[inline(always)]
-pub unsafe fn syscall5(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) -> usize {
     let ret: usize;
     asm!("svc 0" : "={x0}"(ret)
          : "{x8}"(n) "{x0}"(a1) "{x1}"(a2) "{x2}"(a3) "{x3}"(a4) "{x4}"(a5)
@@ -88,14 +77,15 @@ pub unsafe fn syscall5(n: usize,
 }
 
 #[inline(always)]
-pub unsafe fn syscall6(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize,
-                       a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    n: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+    a6: usize,
+) -> usize {
     let ret: usize;
     asm!("svc 0"
          : "={x0}"(ret)

--- a/src/platform/linux-armeabi/mod.rs
+++ b/src/platform/linux-armeabi/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod nr;
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret: usize;
@@ -22,6 +23,7 @@ pub unsafe fn syscall0(n: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     let ret: usize;
@@ -33,6 +35,7 @@ pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     let ret: usize;
@@ -44,6 +47,7 @@ pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     let ret: usize;
@@ -55,6 +59,7 @@ pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall4(n: usize,
                        a1: usize,
@@ -71,6 +76,7 @@ pub unsafe fn syscall4(n: usize,
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall5(n: usize,
                        a1: usize,
@@ -87,6 +93,7 @@ pub unsafe fn syscall5(n: usize,
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall6(n: usize,
                        a1: usize,
@@ -106,6 +113,7 @@ pub unsafe fn syscall6(n: usize,
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall7(n: usize,
                        a1: usize,

--- a/src/platform/linux-armeabi/mod.rs
+++ b/src/platform/linux-armeabi/mod.rs
@@ -61,12 +61,7 @@ pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall4(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize, a4: usize) -> usize {
     let ret: usize;
     asm!("swi $$0"
          : "={r0}"(ret)
@@ -78,13 +73,7 @@ pub unsafe fn syscall4(n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall5(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) -> usize {
     let ret: usize;
     asm!("swi $$0" : "={r0}"(ret)
          : "{r7}"(n) "{r0}"(a1) "{r1}"(a2) "{r2}"(a3) "{r3}"(a4) "{r4}"(a5)
@@ -95,14 +84,15 @@ pub unsafe fn syscall5(n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall6(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize,
-                       a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    n: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+    a6: usize,
+) -> usize {
     let ret: usize;
     asm!("swi $$0"
          : "={r0}"(ret)
@@ -115,15 +105,16 @@ pub unsafe fn syscall6(n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall7(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize,
-                       a6: usize,
-                       a7: usize)
-                       -> usize {
+pub unsafe fn syscall7(
+    n: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+    a6: usize,
+    a7: usize,
+) -> usize {
     let ret: usize;
     asm!("swi $$0"
          : "={r0}"(ret)

--- a/src/platform/linux-mips/mod.rs
+++ b/src/platform/linux-mips/mod.rs
@@ -63,11 +63,7 @@ pub unsafe fn syscall2(mut nr: usize, a1: usize, a2: usize) -> usize {
 }
 
 #[inline(always)]
-pub unsafe fn syscall3(mut nr: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize)
-                       -> usize {
+pub unsafe fn syscall3(mut nr: usize, a1: usize, a2: usize, a3: usize) -> usize {
     let success: usize;
     asm!("syscall"
          : "+{$2}"(nr) "={$7}"(success)
@@ -82,28 +78,28 @@ pub unsafe fn syscall3(mut nr: usize,
 }
 
 #[inline(always)]
-pub unsafe fn syscall4(mut nr: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       mut a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(mut nr: usize, a1: usize, a2: usize, a3: usize, mut a4: usize) -> usize {
     asm!("syscall"
          : "+{$2}"(nr) "+{$7}"(a4)
          : "{$4}"(a1) "{$5}"(a2) "{$6}"(a3)
          : "$8" "$9" "$10" "$11" "$12" "$13" "$14" "$15" "$24" "$25" "memory"
          : "volatile");
-    if a4 == 0 { nr } else { -(nr as isize) as usize }
+    if a4 == 0 {
+        nr
+    } else {
+        -(nr as isize) as usize
+    }
 }
 
 #[inline(always)]
-pub unsafe fn syscall5(mut nr: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       mut a4: usize,
-                       a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(
+    mut nr: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    mut a4: usize,
+    a5: usize,
+) -> usize {
     asm!(".set noat
           subu $$29,20
           sw $5, 16($$29)
@@ -114,18 +110,23 @@ pub unsafe fn syscall5(mut nr: usize,
          : "{$4}"(a1) "{$5}"(a2) "{$6}"(a3) "r"(a5)
          : "$8" "$9" "$10" "$11" "$12" "$13" "$14" "$15" "$24" "$25" "memory"
          : "volatile");
-    if a4 == 0 { nr } else { -(nr as isize) as usize }
+    if a4 == 0 {
+        nr
+    } else {
+        -(nr as isize) as usize
+    }
 }
 
 #[inline(always)]
-pub unsafe fn syscall6(mut nr: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       mut a4: usize,
-                       a5: usize,
-                       a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    mut nr: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    mut a4: usize,
+    a5: usize,
+    a6: usize,
+) -> usize {
     asm!(".set noat
           subu $$29,24
           sw $5, 16($$29)
@@ -137,5 +138,9 @@ pub unsafe fn syscall6(mut nr: usize,
          : "{$4}"(a1) "{$5}"(a2) "{$6}"(a3) "r"(a5) "r"(a6)
          : "$8" "$9" "$10" "$11" "$12" "$13" "$14" "$15" "$24" "$25" "memory"
          : "volatile");
-    if a4 == 0 { nr } else { -(nr as isize) as usize }
+    if a4 == 0 {
+        nr
+    } else {
+        -(nr as isize) as usize
+    }
 }

--- a/src/platform/linux-mips64/mod.rs
+++ b/src/platform/linux-mips64/mod.rs
@@ -59,11 +59,7 @@ pub unsafe fn syscall2(mut nr: usize, a1: usize, a2: usize) -> usize {
 }
 
 #[inline(always)]
-pub unsafe fn syscall3(mut nr: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize)
-                       -> usize {
+pub unsafe fn syscall3(mut nr: usize, a1: usize, a2: usize, a3: usize) -> usize {
     let success: usize;
     asm!("syscall"
          : "+{$2}"(nr) "={$7}"(success)
@@ -78,49 +74,58 @@ pub unsafe fn syscall3(mut nr: usize,
 }
 
 #[inline(always)]
-pub unsafe fn syscall4(mut nr: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       mut a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(mut nr: usize, a1: usize, a2: usize, a3: usize, mut a4: usize) -> usize {
     asm!("syscall"
          : "+{$2}"(nr) "+{$7}"(a4)
          : "{$4}"(a1) "{$5}"(a2) "{$6}"(a3)
          : "$8" "$9" "$10" "$11" "$12" "$13" "$14" "$15" "$24" "$25" "memory"
          : "volatile");
-    if a4 == 0 { nr } else { -(nr as isize) as usize }
+    if a4 == 0 {
+        nr
+    } else {
+        -(nr as isize) as usize
+    }
 }
 
 #[inline(always)]
-pub unsafe fn syscall5(mut nr: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       mut a4: usize,
-                       a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(
+    mut nr: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    mut a4: usize,
+    a5: usize,
+) -> usize {
     asm!("syscall"
          : "+{$2}"(nr) "+{$7}"(a4)
          : "{$4}"(a1) "{$5}"(a2) "{$6}"(a3) "{$8}"(a5)
          : "$9" "$10" "$11" "$12" "$13" "$14" "$15" "$24" "$25" "memory"
          : "volatile");
-    if a4 == 0 { nr } else { -(nr as isize) as usize }
+    if a4 == 0 {
+        nr
+    } else {
+        -(nr as isize) as usize
+    }
 }
 
 #[inline(always)]
-pub unsafe fn syscall6(mut nr: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       mut a4: usize,
-                       a5: usize,
-                       a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    mut nr: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    mut a4: usize,
+    a5: usize,
+    a6: usize,
+) -> usize {
     asm!("syscall"
          : "+{$2}"(nr) "+{$7}"(a4)
          : "{$4}"(a1) "{$5}"(a2) "{$6}"(a3) "{$8}"(a5) "{$9}"(a6)
          : "$10" "$11" "$12" "$13" "$14" "$15" "$24" "$25" "memory"
          : "volatile");
-    if a4 == 0 { nr } else { -(nr as isize) as usize }
+    if a4 == 0 {
+        nr
+    } else {
+        -(nr as isize) as usize
+    }
 }

--- a/src/platform/linux-powerpc/mod.rs
+++ b/src/platform/linux-powerpc/mod.rs
@@ -19,6 +19,7 @@
 
 pub mod nr;
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall0(mut n: usize) -> usize {
     let ret: usize;
@@ -33,6 +34,7 @@ pub unsafe fn syscall0(mut n: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall1(mut n: usize, mut a1: usize) -> usize {
     asm!("sc
@@ -46,6 +48,7 @@ pub unsafe fn syscall1(mut n: usize, mut a1: usize) -> usize {
     a1
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall2(mut n: usize, mut a1: usize, mut a2: usize) -> usize {
     asm!("sc
@@ -59,12 +62,9 @@ pub unsafe fn syscall2(mut n: usize, mut a1: usize, mut a2: usize) -> usize {
     a1
 }
 
+#[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall3(mut n: usize,
-                       mut a1: usize,
-                       mut a2: usize,
-                       mut a3: usize)
-                       -> usize {
+pub unsafe fn syscall3(mut n: usize, mut a1: usize, mut a2: usize, mut a3: usize) -> usize {
     asm!("sc
           bns+ 1f
           neg $1, $1
@@ -76,13 +76,15 @@ pub unsafe fn syscall3(mut n: usize,
     a1
 }
 
+#[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall4(mut n: usize,
-                       mut a1: usize,
-                       mut a2: usize,
-                       mut a3: usize,
-                       mut a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(
+    mut n: usize,
+    mut a1: usize,
+    mut a2: usize,
+    mut a3: usize,
+    mut a4: usize,
+) -> usize {
     asm!("sc
           bns+ 1f
           neg $1, $1
@@ -94,14 +96,16 @@ pub unsafe fn syscall4(mut n: usize,
     a1
 }
 
+#[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall5(mut n: usize,
-                       mut a1: usize,
-                       mut a2: usize,
-                       mut a3: usize,
-                       mut a4: usize,
-                       mut a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(
+    mut n: usize,
+    mut a1: usize,
+    mut a2: usize,
+    mut a3: usize,
+    mut a4: usize,
+    mut a5: usize,
+) -> usize {
     asm!("sc
           bns+ 1f
           neg $1, $1
@@ -114,15 +118,17 @@ pub unsafe fn syscall5(mut n: usize,
     a1
 }
 
+#[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall6(mut n: usize,
-                       mut a1: usize,
-                       mut a2: usize,
-                       mut a3: usize,
-                       mut a4: usize,
-                       mut a5: usize,
-                       mut a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    mut n: usize,
+    mut a1: usize,
+    mut a2: usize,
+    mut a3: usize,
+    mut a4: usize,
+    mut a5: usize,
+    mut a6: usize,
+) -> usize {
     asm!("sc
           bns+ 1f
           neg $1, $1

--- a/src/platform/linux-powerpc64/mod.rs
+++ b/src/platform/linux-powerpc64/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod nr;
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall0(mut n: usize) -> usize {
     let ret: usize;
@@ -30,6 +31,7 @@ pub unsafe fn syscall0(mut n: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall1(mut n: usize, mut a1: usize) -> usize {
     asm!("sc
@@ -43,6 +45,7 @@ pub unsafe fn syscall1(mut n: usize, mut a1: usize) -> usize {
     a1
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall2(mut n: usize, mut a1: usize, mut a2: usize) -> usize {
     asm!("sc
@@ -56,12 +59,9 @@ pub unsafe fn syscall2(mut n: usize, mut a1: usize, mut a2: usize) -> usize {
     a1
 }
 
+#[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall3(mut n: usize,
-                       mut a1: usize,
-                       mut a2: usize,
-                       mut a3: usize)
-                       -> usize {
+pub unsafe fn syscall3(mut n: usize, mut a1: usize, mut a2: usize, mut a3: usize) -> usize {
     asm!("sc
           bns+ 1f
           neg $1, $1
@@ -73,13 +73,15 @@ pub unsafe fn syscall3(mut n: usize,
     a1
 }
 
+#[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall4(mut n: usize,
-                       mut a1: usize,
-                       mut a2: usize,
-                       mut a3: usize,
-                       mut a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(
+    mut n: usize,
+    mut a1: usize,
+    mut a2: usize,
+    mut a3: usize,
+    mut a4: usize,
+) -> usize {
     asm!("sc
           bns+ 1f
           neg $1, $1
@@ -91,14 +93,16 @@ pub unsafe fn syscall4(mut n: usize,
     a1
 }
 
+#[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall5(mut n: usize,
-                       mut a1: usize,
-                       mut a2: usize,
-                       mut a3: usize,
-                       mut a4: usize,
-                       mut a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(
+    mut n: usize,
+    mut a1: usize,
+    mut a2: usize,
+    mut a3: usize,
+    mut a4: usize,
+    mut a5: usize,
+) -> usize {
     asm!("sc
           bns+ 1f
           neg $1, $1
@@ -111,15 +115,17 @@ pub unsafe fn syscall5(mut n: usize,
     a1
 }
 
+#[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall6(mut n: usize,
-                       mut a1: usize,
-                       mut a2: usize,
-                       mut a3: usize,
-                       mut a4: usize,
-                       mut a5: usize,
-                       mut a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    mut n: usize,
+    mut a1: usize,
+    mut a2: usize,
+    mut a3: usize,
+    mut a4: usize,
+    mut a5: usize,
+    mut a6: usize,
+) -> usize {
     asm!("sc
           bns+ 1f
           neg $1, $1

--- a/src/platform/linux-sparc64/mod.rs
+++ b/src/platform/linux-sparc64/mod.rs
@@ -55,11 +55,7 @@ pub unsafe fn syscall2(nr: usize, mut a1: usize, a2: usize) -> usize {
 }
 
 #[inline(always)]
-pub unsafe fn syscall3(nr: usize,
-                       mut a1: usize,
-                       a2: usize,
-                       a3: usize)
-                       -> usize {
+pub unsafe fn syscall3(nr: usize, mut a1: usize, a2: usize, a3: usize) -> usize {
     asm!("t 109
           bcc,pt %xcc, 1f
           sub %g0, %o0, %o0
@@ -72,12 +68,7 @@ pub unsafe fn syscall3(nr: usize,
 }
 
 #[inline(always)]
-pub unsafe fn syscall4(nr: usize,
-                       mut a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(nr: usize, mut a1: usize, a2: usize, a3: usize, a4: usize) -> usize {
     asm!("t 109
           bcc,pt %xcc, 1f
           sub %g0, %o0, %o0
@@ -90,13 +81,14 @@ pub unsafe fn syscall4(nr: usize,
 }
 
 #[inline(always)]
-pub unsafe fn syscall5(nr: usize,
-                       mut a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(
+    nr: usize,
+    mut a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+) -> usize {
     asm!("t 109
           bcc,pt %xcc, 1f
           sub %g0, %o0, %o0
@@ -109,14 +101,15 @@ pub unsafe fn syscall5(nr: usize,
 }
 
 #[inline(always)]
-pub unsafe fn syscall6(nr: usize,
-                       mut a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize,
-                       a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    nr: usize,
+    mut a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+    a6: usize,
+) -> usize {
     asm!("t 109
           bcc,pt %xcc, 1f
           sub %g0, %o0, %o0

--- a/src/platform/linux-x86/mod.rs
+++ b/src/platform/linux-x86/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod nr;
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall0(mut n: usize) -> usize {
     asm!("int $$0x80"
@@ -21,6 +22,7 @@ pub unsafe fn syscall0(mut n: usize) -> usize {
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall1(mut n: usize, a1: usize) -> usize {
     asm!("int $$0x80"
@@ -31,6 +33,7 @@ pub unsafe fn syscall1(mut n: usize, a1: usize) -> usize {
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall2(mut n: usize, a1: usize, a2: usize) -> usize {
     asm!("int $$0x80"
@@ -41,6 +44,7 @@ pub unsafe fn syscall2(mut n: usize, a1: usize, a2: usize) -> usize {
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall3(mut n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     asm!("int $$0x80"
@@ -51,6 +55,7 @@ pub unsafe fn syscall3(mut n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall4(mut n: usize,
                        a1: usize,
@@ -66,6 +71,7 @@ pub unsafe fn syscall4(mut n: usize,
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall5(mut n: usize,
                        a1: usize,
@@ -82,6 +88,7 @@ pub unsafe fn syscall5(mut n: usize,
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall6(n: usize,
                        a1: usize,

--- a/src/platform/linux-x86/mod.rs
+++ b/src/platform/linux-x86/mod.rs
@@ -57,12 +57,7 @@ pub unsafe fn syscall3(mut n: usize, a1: usize, a2: usize, a3: usize) -> usize {
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall4(mut n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(mut n: usize, a1: usize, a2: usize, a3: usize, a4: usize) -> usize {
     asm!("int $$0x80"
          : "+{eax}"(n)
          : "{ebx}"(a1) "{ecx}"(a2) "{edx}"(a3) "{esi}"(a4)
@@ -73,13 +68,14 @@ pub unsafe fn syscall4(mut n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall5(mut n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(
+    mut n: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+) -> usize {
     asm!("int $$0x80"
          : "+{eax}"(n)
          : "{ebx}"(a1) "{ecx}"(a2) "{edx}"(a3) "{esi}"(a4) "{edi}"(a5)
@@ -90,14 +86,15 @@ pub unsafe fn syscall5(mut n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall6(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize,
-                       a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    n: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+    a6: usize,
+) -> usize {
     let ret: usize;
 
     // XXX: this fails when building without optimizations:

--- a/src/platform/linux-x86_64/mod.rs
+++ b/src/platform/linux-x86_64/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod nr;
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall0(mut n: usize) -> usize {
     asm!("syscall"
@@ -21,6 +22,7 @@ pub unsafe fn syscall0(mut n: usize) -> usize {
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall1(mut n: usize, a1: usize) -> usize {
     asm!("syscall"
@@ -31,6 +33,7 @@ pub unsafe fn syscall1(mut n: usize, a1: usize) -> usize {
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall2(mut n: usize, a1: usize, a2: usize) -> usize {
     asm!("syscall"
@@ -41,6 +44,7 @@ pub unsafe fn syscall2(mut n: usize, a1: usize, a2: usize) -> usize {
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall3(mut n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     asm!("syscall"
@@ -51,6 +55,7 @@ pub unsafe fn syscall3(mut n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall4(mut n: usize,
                        a1: usize,
@@ -66,6 +71,7 @@ pub unsafe fn syscall4(mut n: usize,
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall5(mut n: usize,
                        a1: usize,
@@ -82,6 +88,7 @@ pub unsafe fn syscall5(mut n: usize,
     n
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall6(mut n: usize,
                        a1: usize,

--- a/src/platform/linux-x86_64/mod.rs
+++ b/src/platform/linux-x86_64/mod.rs
@@ -57,12 +57,7 @@ pub unsafe fn syscall3(mut n: usize, a1: usize, a2: usize, a3: usize) -> usize {
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall4(mut n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(mut n: usize, a1: usize, a2: usize, a3: usize, a4: usize) -> usize {
     asm!("syscall"
          : "+{rax}"(n)
          : "{rdi}"(a1) "{rsi}"(a2) "{rdx}"(a3) "{r10}"(a4)
@@ -73,13 +68,14 @@ pub unsafe fn syscall4(mut n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall5(mut n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(
+    mut n: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+) -> usize {
     asm!("syscall"
          : "+{rax}"(n)
          : "{rdi}"(a1) "{rsi}"(a2) "{rdx}"(a3) "{r10}"(a4) "{r8}"(a5)
@@ -90,14 +86,15 @@ pub unsafe fn syscall5(mut n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall6(mut n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize,
-                       a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    mut n: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+    a6: usize,
+) -> usize {
     asm!("syscall"
          : "+{rax}"(n)
          : "{rdi}"(a1) "{rsi}"(a2) "{rdx}"(a3) "{r10}"(a4) "{r8}"(a5)"{r9}"(a6)

--- a/src/platform/macos-x86_64/mod.rs
+++ b/src/platform/macos-x86_64/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod nr;
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret: usize;
@@ -21,6 +22,7 @@ pub unsafe fn syscall0(n: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     let ret: usize;
@@ -31,6 +33,7 @@ pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     let ret: usize;
@@ -41,6 +44,7 @@ pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     let ret: usize;
@@ -51,6 +55,7 @@ pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall4(n: usize,
                        a1: usize,
@@ -67,6 +72,7 @@ pub unsafe fn syscall4(n: usize,
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall5(n: usize,
                        a1: usize,
@@ -84,6 +90,7 @@ pub unsafe fn syscall5(n: usize,
     ret
 }
 
+#[cfg(asm)]
 #[inline(always)]
 pub unsafe fn syscall6(n: usize,
                        a1: usize,

--- a/src/platform/macos-x86_64/mod.rs
+++ b/src/platform/macos-x86_64/mod.rs
@@ -57,12 +57,7 @@ pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall4(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize)
-                       -> usize {
+pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize, a4: usize) -> usize {
     let ret: usize;
     asm!("syscall" : "={rax}"(ret)
                    : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
@@ -74,13 +69,7 @@ pub unsafe fn syscall4(n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall5(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize)
-                       -> usize {
+pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) -> usize {
     let ret: usize;
     asm!("syscall" : "={rax}"(ret)
                    : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
@@ -92,14 +81,15 @@ pub unsafe fn syscall5(n: usize,
 
 #[cfg(asm)]
 #[inline(always)]
-pub unsafe fn syscall6(n: usize,
-                       a1: usize,
-                       a2: usize,
-                       a3: usize,
-                       a4: usize,
-                       a5: usize,
-                       a6: usize)
-                       -> usize {
+pub unsafe fn syscall6(
+    n: usize,
+    a1: usize,
+    a2: usize,
+    a3: usize,
+    a4: usize,
+    a5: usize,
+    a6: usize,
+) -> usize {
     let ret: usize;
     asm!("syscall" : "={rax}"(ret)
                    : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -16,8 +16,10 @@ fn ebadf() {
     static MESSAGE: &'static str = "Hello, world!";
 
     unsafe {
-        assert_eq!(syscall!(WRITE, 4, MESSAGE.as_ptr(), MESSAGE.len()) as isize,
-                   -9)
+        assert_eq!(
+            syscall!(WRITE, 4, MESSAGE.as_ptr(), MESSAGE.len()) as isize,
+            -9
+        )
     }
 }
 


### PR DESCRIPTION
`asm!` is still a way from being stabilised, but it would be really useful to use this crate on stable (though unsafe) rust.

This PR adds a `build.rs` which detects if you're on stable/beta vs nightly and uses GCC to compile the `syscall<n>` functions from small C snippets (using `__asm__`).  The C code is, well should be, equivalent to the rust code, though I've not been able to test on any platform other than x86_64 linux.

A minor disadvantage, the C functions can't easily be inlined (though I suspect LTO might be able to).

Platform support (compared to the rust implementations):

* [x] linux-x86
* [x] linux-x86_64
* [x] linux-powerpc
* [x] linux-powerpc64
* [x] linux-armeabi
* [x] freebsd-x86_64
* [ ] linux-sparc64
* [ ] linux-mips
* [ ] linux-mips64
* [ ] linux-aarch64
* [x] macos-x86_64