### PR TITLE
Enable conditional compilation for target_os="android"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,52 +22,52 @@ pub use platform::*;
 
 pub mod macros;
 
-#[cfg(all(target_os = "linux",
+#[cfg(all(any(target_os = "linux", target_os = "android"),
           target_arch = "aarch64"))]
 #[path="platform/linux-aarch64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
+#[cfg(all(any(target_os = "linux", target_os = "android"),
           target_arch = "arm"))]
 #[path="platform/linux-armeabi/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
+#[cfg(all(any(target_os = "linux", target_os = "android"),
           target_arch = "mips"))]
 #[path="platform/linux-mips/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
+#[cfg(all(any(target_os = "linux", target_os = "android"),
           target_arch = "mips64"))]
 #[path="platform/linux-mips64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
+#[cfg(all(any(target_os = "linux", target_os = "android"),
           target_arch = "powerpc"))]
 #[path="platform/linux-powerpc/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
+#[cfg(all(any(target_os = "linux", target_os = "android"),
           target_arch = "powerpc64"))]
 #[path="platform/linux-powerpc64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
+#[cfg(all(any(target_os = "linux", target_os = "android"),
           target_arch = "riscv64"))]
 #[path="platform/linux-riscv64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
+#[cfg(all(any(target_os = "linux", target_os = "android"),
           target_arch = "sparc64"))]
 #[path="platform/linux-sparc64/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
+#[cfg(all(any(target_os = "linux", target_os = "android"),
           target_arch = "x86"))]
 #[path="platform/linux-x86/mod.rs"]
 pub mod platform;
 
-#[cfg(all(target_os = "linux",
+#[cfg(all(any(target_os = "linux", target_os = "android"),
           target_arch = "x86_64"))]
 #[path="platform/linux-x86_64/mod.rs"]
 pub mod platform;


### PR DESCRIPTION
As stated in the [Android developer documentation](https://source.android.com/devices/architecture/kernel/android-common): 

> The AOSP common kernels (also known as the Android common kernels or ACKs) are downstream of kernel.org kernels and include patches of interest to the Android community that haven't been merged into mainline or Long Term Supported (LTS) kernels. 

We can assume that the system calls on Linux are also supported on Android, and they have the same system call number and parameters.

The pr loosens the conditional compilation restrictions a bit, so that this crate can be compiled in the android-related target.