### PR TITLE
Port some platforms from `llvm_asm` to `asm`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          # asm! is stable and llvm_asm! still exists
+          toolchain: nightly-2022-01-14
           target: ${{ matrix.target }}
           override: true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 // Reference http://man7.org/linux/man-pages/man2/syscall.2.html
 
 #![deny(warnings)]
-#![feature(llvm_asm)]
 #![no_std]
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,18 @@
 
 // Reference http://man7.org/linux/man-pages/man2/syscall.2.html
 
+#![allow(deprecated)] // llvm_asm!
 #![deny(warnings)]
 #![no_std]
+#![cfg_attr(any(
+    target_arch = "arm",
+    target_arch = "mips",
+    target_arch = "mips64",
+    target_arch = "powerpc",
+    target_arch = "powerpc64",
+    target_arch = "sparc64",
+    target_arch = "x86"
+), feature(llvm_asm))]
 
 #[cfg(test)]
 extern crate std;

--- a/src/platform/freebsd-x86_64/mod.rs
+++ b/src/platform/freebsd-x86_64/mod.rs
@@ -9,83 +9,110 @@
 
 //! This library was built for x86-64 FreeBSD.
 
+use core::arch::asm;
+
 pub mod nr;
 
 #[inline(always)]
-pub unsafe fn syscall0(n: usize) -> usize {
-    let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
-    ret
+pub unsafe fn syscall0(mut n: usize) -> usize {
+    asm!(
+        "syscall",
+        inout("rax") n,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
+    n
 }
 
 #[inline(always)]
-pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
-    let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
-    ret
+pub unsafe fn syscall1(mut n: usize, a1: usize) -> usize {
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
+    n
 }
 
 #[inline(always)]
-pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
-    let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
-    ret
+pub unsafe fn syscall2(mut n: usize, a1: usize, a2: usize) -> usize {
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
+    n
 }
 
 #[inline(always)]
-pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
-    let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
-    ret
+pub unsafe fn syscall3(mut n: usize, a1: usize, a2: usize, a3: usize) -> usize {
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
+    n
 }
 
 #[inline(always)]
-pub unsafe fn syscall4(n: usize,
+pub unsafe fn syscall4(mut n: usize,
                        a1: usize,
                        a2: usize,
                        a3: usize,
                        a4: usize)
                        -> usize {
-    let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
-                     "{r10}"(a4)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
-    ret
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
+    n
 }
 
 #[inline(always)]
-pub unsafe fn syscall5(n: usize,
+pub unsafe fn syscall5(mut n: usize,
                        a1: usize,
                        a2: usize,
                        a3: usize,
                        a4: usize,
                        a5: usize)
                        -> usize {
-    let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
-                     "{r10}"(a4), "{r8}"(a5)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
-    ret
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        in("r8") a5,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
+    n
 }
 
 #[inline(always)]
-pub unsafe fn syscall6(n: usize,
+pub unsafe fn syscall6(mut n: usize,
                        a1: usize,
                        a2: usize,
                        a3: usize,
@@ -93,11 +120,18 @@ pub unsafe fn syscall6(n: usize,
                        a5: usize,
                        a6: usize)
                        -> usize {
-    let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
-                     "{r10}"(a4), "{r8}"(a5), "{r9}"(a6)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
-    ret
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        in("r8") a5,
+        in("r9") a6,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
+    n
 }

--- a/src/platform/linux-aarch64/mod.rs
+++ b/src/platform/linux-aarch64/mod.rs
@@ -9,49 +9,58 @@
 
 //! This library was built for aarch64 Linux.
 
+use core::arch::asm;
+
 pub mod nr;
 
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret: usize;
-    llvm_asm!("svc 0"
-         : "={x0}"(ret)
-         : "{x8}"(n)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "svc 0",
+        in("x8") n,
+        out("x0") ret,
+        options(nostack),
+    );
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     let ret: usize;
-    llvm_asm!("svc 0"
-         : "={x0}"(ret)
-         : "{x8}"(n) "{x0}"(a1)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "svc 0",
+        in("x8") n,
+        inout("x0") a1 => ret,
+        options(nostack),
+    );
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     let ret: usize;
-    llvm_asm!("svc 0"
-         : "={x0}"(ret)
-         : "{x8}"(n) "{x0}"(a1) "{x1}"(a2)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "svc 0",
+        in("x8") n,
+        inout("x0") a1 => ret,
+        in("x1") a2,
+        options(nostack),
+    );
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     let ret: usize;
-    llvm_asm!("svc 0"
-         : "={x0}"(ret)
-         : "{x8}"(n) "{x0}"(a1) "{x1}"(a2) "{x2}"(a3)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "svc 0",
+        in("x8") n,
+        inout("x0") a1 => ret,
+        in("x1") a2,
+        in("x2") a3,
+        options(nostack),
+    );
     ret
 }
 
@@ -63,11 +72,15 @@ pub unsafe fn syscall4(n: usize,
                        a4: usize)
                        -> usize {
     let ret: usize;
-    llvm_asm!("svc 0"
-         : "={x0}"(ret)
-         : "{x8}"(n) "{x0}"(a1) "{x1}"(a2) "{x2}"(a3) "{x3}"(a4)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "svc 0",
+        in("x8") n,
+        inout("x0") a1 => ret,
+        in("x1") a2,
+        in("x2") a3,
+        in("x3") a4,
+        options(nostack),
+    );
     ret
 }
 
@@ -80,10 +93,16 @@ pub unsafe fn syscall5(n: usize,
                        a5: usize)
                        -> usize {
     let ret: usize;
-    llvm_asm!("svc 0" : "={x0}"(ret)
-         : "{x8}"(n) "{x0}"(a1) "{x1}"(a2) "{x2}"(a3) "{x3}"(a4) "{x4}"(a5)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "svc 0",
+        in("x8") n,
+        inout("x0") a1 => ret,
+        in("x1") a2,
+        in("x2") a3,
+        in("x3") a4,
+        in("x4") a5,
+        options(nostack),
+    );
     ret
 }
 
@@ -97,11 +116,16 @@ pub unsafe fn syscall6(n: usize,
                        a6: usize)
                        -> usize {
     let ret: usize;
-    llvm_asm!("svc 0"
-         : "={x0}"(ret)
-         : "{x8}"(n) "{x0}"(a1) "{x1}"(a2) "{x2}"(a3) "{x3}"(a4) "{x4}"(a5)
-           "{x5}"(a6)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "svc 0",
+        in("x8") n,
+        inout("x0") a1 => ret,
+        in("x1") a2,
+        in("x2") a3,
+        in("x3") a4,
+        in("x4") a5,
+        in("x5") a6,
+        options(nostack),
+    );
     ret
 }

--- a/src/platform/linux-riscv64/mod.rs
+++ b/src/platform/linux-riscv64/mod.rs
@@ -9,49 +9,58 @@
 
 //! This library was built for aarch64 Linux.
 
+use core::arch::asm;
+
 pub mod nr;
 
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret: usize;
-    llvm_asm!("ecall"
-         : "={x10}"(ret)
-         : "{x17}"(n)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "ecall",
+        in("x17") n,
+        out("x10") ret,
+        options(nostack),
+    );
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     let ret: usize;
-    llvm_asm!("ecall"
-         : "={x10}"(ret)
-         : "{x17}"(n) "{x10}"(a1)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "ecall",
+        in("x17") n,
+        inout("x10") a1 => ret,
+        options(nostack),
+    );
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     let ret: usize;
-    llvm_asm!("ecall"
-         : "={x10}"(ret)
-         : "{x17}"(n) "{x10}"(a1) "{x11}"(a2)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "ecall",
+        in("x17") n,
+        inout("x10") a1 => ret,
+        in("x11") a2,
+        options(nostack),
+    );
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     let ret: usize;
-    llvm_asm!("ecall"
-         : "={x10}"(ret)
-         : "{x17}"(n) "{x10}"(a1) "{x11}"(a2) "{x12}"(a3)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "ecall",
+        in("x17") n,
+        inout("x10") a1 => ret,
+        in("x11") a2,
+        in("x12") a3,
+        options(nostack),
+    );
     ret
 }
 
@@ -63,11 +72,15 @@ pub unsafe fn syscall4(n: usize,
                        a4: usize)
                        -> usize {
     let ret: usize;
-    llvm_asm!("ecall"
-         : "={x10}"(ret)
-         : "{x17}"(n) "{x10}"(a1) "{x11}"(a2) "{x12}"(a3) "{x13}"(a4)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "ecall",
+        in("x17") n,
+        inout("x10") a1 => ret,
+        in("x11") a2,
+        in("x12") a3,
+        in("x13") a4,
+        options(nostack),
+    );
     ret
 }
 
@@ -80,10 +93,16 @@ pub unsafe fn syscall5(n: usize,
                        a5: usize)
                        -> usize {
     let ret: usize;
-    llvm_asm!("ecall" : "={x10}"(ret)
-         : "{x17}"(n) "{x10}"(a1) "{x11}"(a2) "{x12}"(a3) "{x13}"(a4) "{x14}"(a5)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "ecall",
+        in("x17") n,
+        inout("x10") a1 => ret,
+        in("x11") a2,
+        in("x12") a3,
+        in("x13") a4,
+        in("x14") a5,
+        options(nostack),
+    );
     ret
 }
 
@@ -97,11 +116,16 @@ pub unsafe fn syscall6(n: usize,
                        a6: usize)
                        -> usize {
     let ret: usize;
-    llvm_asm!("ecall"
-         : "={x10}"(ret)
-         : "{x17}"(n) "{x10}"(a1) "{x11}"(a2) "{x12}"(a3) "{x13}"(a4) "{x14}"(a5)
-           "{x15}"(a6)
-         : "memory" "cc"
-         : "volatile");
+    asm!(
+        "ecall",
+        in("x17") n,
+        inout("x10") a1 => ret,
+        in("x11") a2,
+        in("x12") a3,
+        in("x13") a4,
+        in("x14") a5,
+        in("x15") a6,
+        options(nostack),
+    );
     ret
 }

--- a/src/platform/linux-x86_64/mod.rs
+++ b/src/platform/linux-x86_64/mod.rs
@@ -9,45 +9,61 @@
 
 //! This library was built for x86-64 Linux.
 
+use core::arch::asm;
+
 pub mod nr;
 
 #[inline(always)]
 pub unsafe fn syscall0(mut n: usize) -> usize {
-    llvm_asm!("syscall"
-         : "+{rax}"(n)
-         :
-         : "rcx", "r11", "memory"
-         : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") n,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     n
 }
 
 #[inline(always)]
 pub unsafe fn syscall1(mut n: usize, a1: usize) -> usize {
-    llvm_asm!("syscall"
-         : "+{rax}"(n)
-         : "{rdi}"(a1)
-         : "rcx", "r11", "memory"
-         : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     n
 }
 
 #[inline(always)]
 pub unsafe fn syscall2(mut n: usize, a1: usize, a2: usize) -> usize {
-    llvm_asm!("syscall"
-         : "+{rax}"(n)
-         : "{rdi}"(a1) "{rsi}"(a2)
-         : "rcx", "r11", "memory"
-         : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     n
 }
 
 #[inline(always)]
 pub unsafe fn syscall3(mut n: usize, a1: usize, a2: usize, a3: usize) -> usize {
-    llvm_asm!("syscall"
-         : "+{rax}"(n)
-         : "{rdi}"(a1) "{rsi}"(a2) "{rdx}"(a3)
-         : "rcx", "r11", "memory"
-         : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     n
 }
 
@@ -58,11 +74,17 @@ pub unsafe fn syscall4(mut n: usize,
                        a3: usize,
                        a4: usize)
                        -> usize {
-    llvm_asm!("syscall"
-         : "+{rax}"(n)
-         : "{rdi}"(a1) "{rsi}"(a2) "{rdx}"(a3) "{r10}"(a4)
-         : "rcx", "r11", "memory"
-         : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     n
 }
 
@@ -74,11 +96,18 @@ pub unsafe fn syscall5(mut n: usize,
                        a4: usize,
                        a5: usize)
                        -> usize {
-    llvm_asm!("syscall"
-         : "+{rax}"(n)
-         : "{rdi}"(a1) "{rsi}"(a2) "{rdx}"(a3) "{r10}"(a4) "{r8}"(a5)
-         : "rcx", "r11", "memory"
-         : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        in("r8") a5,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     n
 }
 
@@ -91,10 +120,18 @@ pub unsafe fn syscall6(mut n: usize,
                        a5: usize,
                        a6: usize)
                        -> usize {
-    llvm_asm!("syscall"
-         : "+{rax}"(n)
-         : "{rdi}"(a1) "{rsi}"(a2) "{rdx}"(a3) "{r10}"(a4) "{r8}"(a5)"{r9}"(a6)
-         : "rcx", "r11", "memory"
-         : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") n,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        in("r8") a5,
+        in("r9") a6,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     n
 }

--- a/src/platform/macos-x86_64/mod.rs
+++ b/src/platform/macos-x86_64/mod.rs
@@ -9,6 +9,8 @@
 
 //! This library was built for x86-64 MacOS.
 
+use core::arch::asm;
+
 pub mod nr;
 
 const MACOS_SYSCALL_PREFIX: usize = 33554432;
@@ -16,40 +18,58 @@ const MACOS_SYSCALL_PREFIX: usize = 33554432;
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n + MACOS_SYSCALL_PREFIX)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") (n + MACOS_SYSCALL_PREFIX) => ret,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n + MACOS_SYSCALL_PREFIX), "{rdi}"(a1)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") (n + MACOS_SYSCALL_PREFIX) => ret,
+        in("rdi") a1,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n + MACOS_SYSCALL_PREFIX), "{rdi}"(a1), "{rsi}"(a2)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") (n + MACOS_SYSCALL_PREFIX) => ret,
+        in("rdi") a1,
+        in("rsi") a2,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     ret
 }
 
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n + MACOS_SYSCALL_PREFIX), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") (n + MACOS_SYSCALL_PREFIX) => ret,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     ret
 }
 
@@ -61,11 +81,17 @@ pub unsafe fn syscall4(n: usize,
                        a4: usize)
                        -> usize {
     let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n + MACOS_SYSCALL_PREFIX), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
-                     "{r10}"(a4)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") (n + MACOS_SYSCALL_PREFIX) => ret,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     ret
 }
 
@@ -78,11 +104,18 @@ pub unsafe fn syscall5(n: usize,
                        a5: usize)
                        -> usize {
     let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n + MACOS_SYSCALL_PREFIX), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
-                     "{r10}"(a4), "{r8}"(a5)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") (n + MACOS_SYSCALL_PREFIX) => ret,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        in("r8") a5,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     ret
 }
 
@@ -96,10 +129,18 @@ pub unsafe fn syscall6(n: usize,
                        a6: usize)
                        -> usize {
     let ret: usize;
-    llvm_asm!("syscall" : "={rax}"(ret)
-                   : "{rax}"(n + MACOS_SYSCALL_PREFIX), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
-                     "{r10}"(a4), "{r8}"(a5), "{r9}"(a6)
-                   : "rcx", "r11", "memory"
-                   : "volatile");
+    asm!(
+        "syscall",
+        inout("rax") (n + MACOS_SYSCALL_PREFIX) => ret,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        in("r10") a4,
+        in("r8") a5,
+        in("r9") a6,
+        out("rcx") _,
+        out("r11") _,
+        options(nostack),
+    );
     ret
 }


### PR DESCRIPTION
Only ports platforms where the required changes are trivial.

The reason for this change is that `llvm_asm` is removed from nightly, so it
doesn't compile any more on any current compiler, while `asm` is being stabilised
(currently stable on beta).

The major omission in this commit is the linux x86 (32 bit) platform. The new `asm`
macro doesn't allow the esi and ebp registers to be used as inputs or outputs or
clobbers, which makes the port non-trivial for this platform. Similarly on armeabi
the r6 register is not allowed as input, output or clobber.